### PR TITLE
added if else statement to handle post_act_ln

### DIFF
--- a/bitnet/bit_ffn.py
+++ b/bitnet/bit_ffn.py
@@ -104,13 +104,19 @@ class BitFeedForward(nn.Module):
             project_in = nn.Sequential(
                 BitLinear(dim, inner_dim, bias=not no_bias, *args, **kwargs), activation
             )
-
-        self.ff = nn.Sequential(
+        if post_act_ln:
+            self.ff = nn.Sequential(
             project_in,
-            nn.LayerNorm(inner_dim) if post_act_ln else None,
+            nn.LayerNorm(inner_dim),
             nn.Dropout(dropout),
             BitLinear(inner_dim, dim_out, bias=not no_bias, *args, **kwargs),
         )
+        else:
+            self.ff = nn.Sequential(
+                project_in,
+                nn.Dropout(dropout),
+                BitLinear(inner_dim, dim_out, bias=not no_bias, *args, **kwargs),
+            )
 
         # init last linear layer to 0
         if zero_init_output:


### PR DESCRIPTION
  - Description: To address an issue where instantiating `BitFeedForward()` with `post_act_ln=False` will result in `TypeError: 'NoneType' object is not callable`, I've added an if-else statement to create different sequences depending on the value of `post_act_ln`. Please see the issue for more details.
  - Issue: https://github.com/kyegomez/BitNet/issues/43, https://github.com/kyegomez/BitNet/issues/53
  - Dependencies: None