### PR TITLE
Fix: Weight quantization sign should be the last operation

### DIFF
--- a/bitnet/bit_linear_new.py
+++ b/bitnet/bit_linear_new.py
@@ -20,8 +20,8 @@ def activation_quant(x: Tensor):
 def weight_quant(w: Tensor):
     scale = w.abs().mean()
     e = w.mean()
-    u = (w - e).sign() * scale
-    return u
+    u = (w - e) * scale
+    return u.sign()
 
 
 class BitLinearNew(nn.Linear):

--- a/bitnet/bitlinear.py
+++ b/bitnet/bitlinear.py
@@ -20,8 +20,8 @@ def activation_quant(x: Tensor):
 def weight_quant(w: Tensor):
     scale = w.abs().mean()
     e = w.mean()
-    u = (w - e).sign() * scale
-    return u
+    u = (w - e) * scale
+    return u.sign()
 
 
 class BitLinear(nn.Linear):


### PR DESCRIPTION
Description: This PR fixes a bug in the weight_quant() function, where the weights do not follow the paper orientation to when to sign the weights.
Basically the sign operation should be the last thing to be done but it's being done before the multiplication of the scale([see this for more informations](https://github.com/kyegomez/BitNet/issues/52#issuecomment-2195646820))

For discussion: The weights and activation are still being done at full precision on BitLinear, it's probably best to convert it to int8 like the paper proposes to provide better speed.

Issue: #52 